### PR TITLE
Run railtie before configuration

### DIFF
--- a/lib/ejson/rails/railtie.rb
+++ b/lib/ejson/rails/railtie.rb
@@ -6,7 +6,7 @@ module EJSON
     private_constant :Rails
 
     class Railtie < Rails::Railtie
-      initializer "ejson-rails.merge_secrets" do
+      config.before_configuration do
         json_files.each do |file|
           next unless valid?(file)
           secrets = JSON.parse(file.read, symbolize_names: true)
@@ -14,17 +14,19 @@ module EJSON
         end
       end
 
-      private
+      class << self
+        private
 
-      def valid?(pathname)
-        pathname.exist?
-      end
+        def valid?(pathname)
+          pathname.exist?
+        end
 
-      def json_files
-        [
-          Rails.root.join("config", "secrets.json"),
-          Rails.root.join("config", "secrets.#{Rails.env}.json"),
-        ]
+        def json_files
+          [
+            Rails.root.join("config", "secrets.json"),
+            Rails.root.join("config", "secrets.#{Rails.env}.json"),
+          ]
+        end
       end
     end
   end

--- a/spec/ejson/rails/railtie_spec.rb
+++ b/spec/ejson/rails/railtie_spec.rb
@@ -9,49 +9,44 @@ RSpec.describe EJSON::Rails::Railtie do
     is_expected.to be_a ::Rails::Railtie
   end
 
-  context 'initialized' do
+  context 'before configuration' do
     before do
       allow_rails.to receive(:root).and_return(fixtures_root)
       allow_rails.to receive_message_chain('application.secrets').and_return(secrets)
     end
 
     it 'merges secrets into application secrets' do
-      run_initializers_of(subject)
+      run_load_hooks
       expect(secrets).to include(:secret)
     end
 
     it 'prioritizes secrets.json' do
-      run_initializers_of(subject)
+      run_load_hooks
       expect(secrets).to include(secret: 'real_api_key')
     end
 
     context 'without secrets.json' do
-      before do
-        allow(subject).to receive(:valid?).and_call_original
-        allow(subject).to receive(:valid?).with(secrets_json).and_return(false)
-      end
+      before { hide_secrets_files(secrets_json) }
 
       it 'falls back to secrets.env.json' do
         expect(Rails).to receive(:env).and_return(:env)
-        run_initializers_of(subject)
+        run_load_hooks
         expect(secrets).to include(secret: 'test_api_key')
       end
 
       it 'does not load anything when Rails.env doesn\'t match' do
         expect(Rails).to receive(:env).and_return(:production)
-        run_initializers_of(subject)
+        run_load_hooks
         expect(secrets).to be_empty
       end
     end
 
     context 'without any json' do
-      before do
-        allow(subject).to receive(:valid?).with(instance_of(Pathname)).and_return(false)
-      end
+      before { hide_secrets_files(secrets_json, environment_secrets_json) }
 
       it 'does not load anything' do
         expect(Rails).to receive(:env).and_return(:production)
-        run_initializers_of(subject)
+        run_load_hooks
         expect(secrets).to be_empty
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require "rails"
 require "ejson/rails"
 
 require_relative "support/path_helper"
+require_relative "support/file_helper"
 require_relative "support/rails_helper"
 
 RSpec.configure do |config|
@@ -19,5 +20,6 @@ RSpec.configure do |config|
   end
 
   config.include PathHelper
+  config.include FileHelper
   config.include RailsHelper
 end

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module FileHelper
+  def hide_secrets_files(*files)
+    allow(EJSON::Rails::Railtie).to receive(:valid?).and_call_original
+    files.each do |file|
+      allow(EJSON::Rails::Railtie).to receive(:valid?).with(file).and_return(false)
+    end
+  end
+end

--- a/spec/support/rails_helper.rb
+++ b/spec/support/rails_helper.rb
@@ -9,7 +9,7 @@ module RailsHelper
     ActiveSupport::OrderedOptions
   end
 
-  def run_initializers_of(railtie)
-    railtie.initializers.each(&:run)
+  def run_load_hooks
+    ActiveSupport.run_load_hooks(:before_configuration)
   end
 end


### PR DESCRIPTION
For secrets that need to be accessed in initializers and configuration steps, we need to load and merge ejson early.