### PR TITLE
Remove secrets after loading

### DIFF
--- a/lib/ejson/rails/railtie.rb
+++ b/lib/ejson/rails/railtie.rb
@@ -20,6 +20,11 @@ module EJSON
         Rails.application.credentials.config.deep_merge!(secrets) do |key|
           raise "A credential already exists with the same name: #{key}"
         end
+
+        # Delete the loaded JSON files so they are no longer readable by the app.
+        if Rails.env.production?
+          json_files.each { |file| file.delete if file.writeable? }
+        end
       end
 
       class << self


### PR DESCRIPTION
# Problem
After an application loads the decrypted EJSON secrets, both the encrypted and decrypted secrets still reside on the filesystem. Since these both contain sensitive data, and are no longer needed by the running application, they are unnecessary residual risk.

# Solution
Remove the files after loading them into Rails Credentials and Secrets.